### PR TITLE
添加pip包信息

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -138,3 +138,6 @@ Push from CLI: [bark-cli](https://github.com/JasonkayZK/bark-cli)
 Quicker Action: https://getquicker.net/Sharedaction?code=e927d844-d212-4428-758d-08d69de12a3b
 
 Bark for Wox: [Wox.Plugin.Bark](https://github.com/Zeroto521/Wox.Plugin.Bark)
+
+Python for Bark: [barknotificator
+](https://github.com/funny-cat-happy/barknotificator)

--- a/README.md
+++ b/README.md
@@ -109,3 +109,7 @@ https://api.day.app/yourkey/时效性通知?level=timeSensitive
 
 ## Bark for Wox
 [https://github.com/Zeroto521/Wox.Plugin.Bark](https://github.com/Zeroto521/Wox.Plugin.Bark)
+
+## Python for Bark
+[barknotificator
+](https://github.com/funny-cat-happy/barknotificator)


### PR DESCRIPTION
添加python包信息到readme中，可以直接通过代码向苹果服务器发送消息，更方便自主控制