### PR TITLE
添加 iPad 支持

### DIFF
--- a/Bark.xcodeproj/project.pbxproj
+++ b/Bark.xcodeproj/project.pbxproj
@@ -184,6 +184,9 @@
 		06F11E7727D9D5FB00F00298 /* QRScannerViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06F11E7627D9D5FB00F00298 /* QRScannerViewController.swift */; };
 		06FB04042C53575400F3A213 /* SharedDefines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB04032C53575400F3A213 /* SharedDefines.swift */; };
 		06FB04052C53575400F3A213 /* SharedDefines.swift in Sources */ = {isa = PBXBuildFile; fileRef = 06FB04032C53575400F3A213 /* SharedDefines.swift */; };
+		1E73F99E2C282822002BF649 /* SectionViewController-iPad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1E73F99D2C282822002BF649 /* SectionViewController-iPad.swift */; };
+		1EFB545D2C314A6800B8E51B /* BarkSplitViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFB545C2C314A6800B8E51B /* BarkSplitViewController.swift */; };
+		1EFB545F2C32514000B8E51B /* SectionViewModel-iPad.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EFB545E2C32514000B8E51B /* SectionViewModel-iPad.swift */; };
 		3428272069AFAFE2C683FEB0 /* libPods-Bark.a in Frameworks */ = {isa = PBXBuildFile; fileRef = CCC722470308049D180876C7 /* libPods-Bark.a */; };
 		879AE4D4178855A9672009E4 /* libPods-NotificationServiceExtension.a in Frameworks */ = {isa = PBXBuildFile; fileRef = B7F8BDFAA047451561798F58 /* libPods-NotificationServiceExtension.a */; };
 		B963F7D5BA7AC2571E71EF66 /* libPods-BarkTests.a in Frameworks */ = {isa = PBXBuildFile; fileRef = 76381A752CCCD4DA6BB2A566 /* libPods-BarkTests.a */; };
@@ -375,6 +378,9 @@
 		06FB04032C53575400F3A213 /* SharedDefines.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SharedDefines.swift; sourceTree = "<group>"; };
 		121D9B1ED4E8D26F345BC5C0 /* Pods-BarkTests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-BarkTests.release.xcconfig"; path = "Target Support Files/Pods-BarkTests/Pods-BarkTests.release.xcconfig"; sourceTree = "<group>"; };
 		138CE8CB688587E893BC5C44 /* Pods-Bark.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bark.debug.xcconfig"; path = "Target Support Files/Pods-Bark/Pods-Bark.debug.xcconfig"; sourceTree = "<group>"; };
+		1E73F99D2C282822002BF649 /* SectionViewController-iPad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SectionViewController-iPad.swift"; sourceTree = "<group>"; };
+		1EFB545C2C314A6800B8E51B /* BarkSplitViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarkSplitViewController.swift; sourceTree = "<group>"; };
+		1EFB545E2C32514000B8E51B /* SectionViewModel-iPad.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "SectionViewModel-iPad.swift"; sourceTree = "<group>"; };
 		519481D715B40109627E1B49 /* Pods-NotificationServiceExtension.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-NotificationServiceExtension.release.xcconfig"; path = "Target Support Files/Pods-NotificationServiceExtension/Pods-NotificationServiceExtension.release.xcconfig"; sourceTree = "<group>"; };
 		76381A752CCCD4DA6BB2A566 /* libPods-BarkTests.a */ = {isa = PBXFileReference; explicitFileType = archive.ar; includeInIndex = 0; path = "libPods-BarkTests.a"; sourceTree = BUILT_PRODUCTS_DIR; };
 		A69B47DA6DB3B168D5770B45 /* Pods-Bark.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Bark.release.xcconfig"; path = "Target Support Files/Pods-Bark/Pods-Bark.release.xcconfig"; sourceTree = "<group>"; };
@@ -447,6 +453,9 @@
 				06EEF332291CCFF400CA228A /* CryptoSettingController.swift */,
 				06EEF334291CD00000CA228A /* CryptoSettingViewModel.swift */,
 				06787C3A2AB82BDB008ABDD7 /* CrashReportViewController.swift */,
+				1E73F99D2C282822002BF649 /* SectionViewController-iPad.swift */,
+				1EFB545E2C32514000B8E51B /* SectionViewModel-iPad.swift */,
+				1EFB545C2C314A6800B8E51B /* BarkSplitViewController.swift */,
 			);
 			path = Controller;
 			sourceTree = "<group>";
@@ -1098,6 +1107,7 @@
 				06840DBB272298FB001B3193 /* BKColor.swift in Sources */,
 				06C2CF232685B88D0034B127 /* TextCell.swift in Sources */,
 				06BBB896256518760076F63E /* NewServerViewModel.swift in Sources */,
+				1EFB545D2C314A6800B8E51B /* BarkSplitViewController.swift in Sources */,
 				06BBB8C92567B6730076F63E /* Operators.swift in Sources */,
 				0603706920E1F89500F4CA05 /* PreviewCardCell.swift in Sources */,
 				0627DABB298B6EA2002F3F69 /* DropBoxView.swift in Sources */,
@@ -1161,12 +1171,14 @@
 				06C2CF252685BDB80034B127 /* SpacerCell.swift in Sources */,
 				06BBB8BC2567B3AD0076F63E /* ArchiveSettingCellViewModel.swift in Sources */,
 				0642B55A27EB13F100453D91 /* MutableTextCell.swift in Sources */,
+				1EFB545F2C32514000B8E51B /* SectionViewModel-iPad.swift in Sources */,
 				06EEF335291CD00000CA228A /* CryptoSettingViewModel.swift in Sources */,
 				0637FA8020E0981E00E80174 /* BarkSettings.swift in Sources */,
 				065BE4402563D649002A8CA4 /* SoundsViewModel.swift in Sources */,
 				065BE4462563D7E5002A8CA4 /* ViewModelType.swift in Sources */,
 				0603706B20E20A7C00F4CA05 /* String+Extension.swift in Sources */,
 				068F66B3247BD84C00DAD25A /* MessageListViewController.swift in Sources */,
+				1E73F99E2C282822002BF649 /* SectionViewController-iPad.swift in Sources */,
 				06BBB8B72567AC140076F63E /* MessageSettingsViewModel.swift in Sources */,
 				06BBB8C12567B3EF0076F63E /* BaseTableViewCell.swift in Sources */,
 				0661A543204FDA4100965E4E /* AppDelegate.swift in Sources */,
@@ -1433,8 +1445,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.fin.bark;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match Development me.fin.bark";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Debug;
 		};
@@ -1455,8 +1469,10 @@
 				PRODUCT_BUNDLE_IDENTIFIER = me.fin.bark;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "match AppStore me.fin.bark";
+				SUPPORTED_PLATFORMS = "iphoneos iphonesimulator";
+				SUPPORTS_MACCATALYST = NO;
 				SWIFT_VERSION = 5.0;
-				TARGETED_DEVICE_FAMILY = 1;
+				TARGETED_DEVICE_FAMILY = "1,2";
 			};
 			name = Release;
 		};

--- a/Bark/AppDelegate.swift
+++ b/Bark/AppDelegate.swift
@@ -78,25 +78,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UNUserNotificationCenterD
         setupRealm()
 
         IQKeyboardManager.shared.enable = true
-
-        let tabBarController = StateStorageTabBarController()
-        tabBarController.tabBar.tintColor = BKColor.grey.darken4
-
-        self.window?.rootViewController = BarkSnackbarController(
-            rootViewController: tabBarController
-        )
-
-        tabBarController.viewControllers = [
-            BarkNavigationController(rootViewController: HomeViewController(viewModel: HomeViewModel())),
-            BarkNavigationController(rootViewController: MessageListViewController(viewModel: MessageListViewModel())),
-            BarkNavigationController(rootViewController: MessageSettingsViewController(viewModel: MessageSettingsViewModel()))
-        ]
-
-        let tabBarItems = [UITabBarItem(title: NSLocalizedString("service"), image: UIImage(named: "baseline_gite_black_24pt"), tag: 0),
-                           UITabBarItem(title: NSLocalizedString("historyMessage"), image: Icon.history, tag: 1),
-                           UITabBarItem(title: NSLocalizedString("settings"), image: UIImage(named: "baseline_manage_accounts_black_24pt"), tag: 2)]
-        for (index, viewController) in tabBarController.viewControllers!.enumerated() {
-            viewController.tabBarItem = tabBarItems[index]
+        if #available(iOS 14, *), UIDevice.current.userInterfaceIdiom == .pad {
+            let splitViewController = BarkSplitViewController.init(style: .doubleColumn)
+            splitViewController.initViewControllers()
+            self.window?.rootViewController = splitViewController;
+        } else {
+            let tabBarController = StateStorageTabBarController()
+            tabBarController.tabBar.tintColor = BKColor.grey.darken4
+            
+            self.window?.rootViewController = BarkSnackbarController(
+                rootViewController: tabBarController
+            )
+            
+            tabBarController.viewControllers = [
+                BarkNavigationController(rootViewController: HomeViewController(viewModel: HomeViewModel())),
+                BarkNavigationController(rootViewController: MessageListViewController(viewModel: MessageListViewModel())),
+                BarkNavigationController(rootViewController: MessageSettingsViewController(viewModel: MessageSettingsViewModel()))
+            ]
+            
+            let tabBarItems = [UITabBarItem(title: NSLocalizedString("service"), image: UIImage(named: "baseline_gite_black_24pt"), tag: 0),
+                               UITabBarItem(title: NSLocalizedString("historyMessage"), image: Icon.history, tag: 1),
+                               UITabBarItem(title: NSLocalizedString("settings"), image: UIImage(named: "baseline_manage_accounts_black_24pt"), tag: 2)]
+            for (index, viewController) in tabBarController.viewControllers!.enumerated() {
+                viewController.tabBarItem = tabBarItems[index]
+            }
         }
         
         // 需先配置好 tabBarController 的 viewControllers，显示时会默认显示上次打开的页面

--- a/Controller/BarkSplitViewController.swift
+++ b/Controller/BarkSplitViewController.swift
@@ -1,0 +1,68 @@
+//
+//  BarkSplitViewController.swift
+//  Bark
+//
+//  Created by sidguan on 2024/6/30.
+//  Copyright © 2024 Fin. All rights reserved.
+//
+
+import UIKit
+import Material
+
+class BarkSplitViewController: UISplitViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+//        self.displayModeButtonItem.tintColor = BKColor.grey.darken4
+//        self.delegate = self
+        // Do any additional setup after loading the view.
+    }
+    
+    func initViewControllers() {
+        if #available(iOS 14, *) {
+            let sectionViewController = BarkNavigationController(rootViewController: SectionViewController_iPad(viewModel: SectionViewModel()));
+            let homeViewController = BarkNavigationController(rootViewController: HomeViewController(viewModel: HomeViewModel()));
+            let tabBarController = StateStorageTabBarController()
+            tabBarController.tabBar.tintColor = BKColor.grey.darken4
+            
+            let snackBarController = BarkSnackbarController(
+                rootViewController: tabBarController
+            )
+            
+            tabBarController.viewControllers = [
+                BarkNavigationController(rootViewController: HomeViewController(viewModel: HomeViewModel())),
+                BarkNavigationController(rootViewController: MessageListViewController(viewModel: MessageListViewModel())),
+                BarkNavigationController(rootViewController: MessageSettingsViewController(viewModel: MessageSettingsViewModel()))
+            ]
+            
+            let tabBarItems = [
+                UITabBarItem(title: NSLocalizedString("service"), image: UIImage(named: "baseline_gite_black_24pt"), tag: 0),
+                UITabBarItem(title: NSLocalizedString("historyMessage"), image: Icon.history, tag: 1),
+                UITabBarItem(title: NSLocalizedString("settings"), image: UIImage(named: "baseline_manage_accounts_black_24pt"), tag: 2)
+            ]
+            for (index, viewController) in tabBarController.viewControllers!.enumerated() {
+                viewController.tabBarItem = tabBarItems[index]
+            }
+            
+            
+            self.setViewController(sectionViewController, for: .primary)
+            self.setViewController(homeViewController, for: .secondary)
+            self.setViewController(snackBarController, for: .compact)
+        }
+    }
+    
+//    func splitViewController(_ splitViewController: UISplitViewController, collapseSecondary secondaryViewController: UIViewController, onto primaryViewController: UIViewController) -> Bool {
+//        return true
+//    }
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Controller/BaseViewController.swift
+++ b/Controller/BaseViewController.swift
@@ -28,7 +28,11 @@ class BaseViewController<T>: UIViewController where T: ViewModel {
     
     override func viewDidLoad() {
         super.viewDidLoad()
-        self.navigationItem.largeTitleDisplayMode = .automatic
+        if UIDevice.current.userInterfaceIdiom == .pad {
+            navigationItem.largeTitleDisplayMode = .never
+        } else {
+            navigationItem.largeTitleDisplayMode = .automatic
+        }
         makeUI()
     }
 

--- a/Controller/SectionViewController-iPad.swift
+++ b/Controller/SectionViewController-iPad.swift
@@ -1,0 +1,134 @@
+//
+//  SectionTableViewController-iPad.swift
+//  Bark
+//
+//  Created by sidguan on 2024/6/23.
+//  Copyright © 2024 Fin. All rights reserved.
+//
+
+import UIKit
+
+import NSObject_Rx
+import RxCocoa
+import RxDataSources
+import RxSwift
+
+class SectionViewController_iPad: BaseViewController<SectionViewModel>, UITableViewDelegate {
+    
+    let tableView: UITableView = {
+        let tableView = UITableView(frame: .zero, style: .grouped)
+        tableView.register(UITableViewCell.self, forCellReuseIdentifier: "\(UITableViewCell.self)")
+        tableView.backgroundColor = BKColor.background.primary
+        return tableView
+    }()
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        self.title = "Bark"
+        navigationItem.largeTitleDisplayMode = .automatic
+    }
+    
+    override func makeUI() {
+        self.view.addSubview(tableView)
+        tableView.delegate = self
+        tableView.snp.makeConstraints { make in
+            make.edges.equalToSuperview()
+        }
+    }
+    
+    override func bindViewModel() {
+        let output = viewModel.transform(input: SectionViewModel.Input())
+        let dataSource = RxTableViewSectionedReloadDataSource<SectionModel<String, SectionItem>> {
+            _, tableView, _, item -> UITableViewCell in
+            guard let cell = tableView.dequeueReusableCell(withIdentifier: "\(UITableViewCell.self)") else {
+                return UITableViewCell()
+            }
+            
+            if #available(iOS 14, *) {
+                cell.backgroundConfiguration = UIBackgroundConfiguration.listPlainCell()
+            }
+            cell.selectionStyle = .gray
+            cell.imageView?.image = item.image
+            cell.imageView?.tintColor = BKColor.grey.darken4
+            cell.textLabel?.text = item.title
+            return cell
+        }
+        tableView.rx
+            .itemSelected
+            .flatMapLatest { indexPath -> Observable<IndexPath> in
+                return Observable.just(indexPath)
+            }
+            .subscribe { indexPath in
+                if #available(iOS 14, *) {
+                    if indexPath.row == 0 {
+                        self.splitViewController?.setViewController(
+                            BarkNavigationController(rootViewController: HomeViewController(viewModel: HomeViewModel())), for: .secondary)
+                    } else if indexPath.row == 1 {
+                        self.splitViewController?.setViewController(
+                            BarkNavigationController(rootViewController: MessageListViewController(viewModel: MessageListViewModel())), for: .secondary)
+                    } else if (indexPath.row == 2) {
+                        
+                        self.splitViewController?.setViewController(
+                            BarkNavigationController(rootViewController: MessageSettingsViewController(viewModel: MessageSettingsViewModel())), for: .secondary)
+                    }
+                } else {
+                    // 正常应该走不到这里了
+                }
+                
+            }.disposed(by: rx.disposeBag)
+        output.items
+            .bind(to: tableView.rx.items(dataSource: dataSource))
+            .disposed(by: rx.disposeBag)
+    }
+
+    
+    func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
+        return 55
+    }
+
+    /*
+    // Override to support conditional editing of the table view.
+    override func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the specified item to be editable.
+        return true
+    }
+    */
+
+    /*
+    // Override to support editing the table view.
+    override func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCell.EditingStyle, forRowAt indexPath: IndexPath) {
+        if editingStyle == .delete {
+            // Delete the row from the data source
+            tableView.deleteRows(at: [indexPath], with: .fade)
+        } else if editingStyle == .insert {
+            // Create a new instance of the appropriate class, insert it into the array, and add a new row to the table view
+        }    
+    }
+    */
+
+    /*
+    // Override to support rearranging the table view.
+    override func tableView(_ tableView: UITableView, moveRowAt fromIndexPath: IndexPath, to: IndexPath) {
+
+    }
+    */
+
+    /*
+    // Override to support conditional rearranging of the table view.
+    override func tableView(_ tableView: UITableView, canMoveRowAt indexPath: IndexPath) -> Bool {
+        // Return false if you do not want the item to be re-orderable.
+        return true
+    }
+    */
+
+    /*
+    // MARK: - Navigation
+
+    // In a storyboard-based application, you will often want to do a little preparation before navigation
+    override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+        // Get the new view controller using segue.destination.
+        // Pass the selected object to the new view controller.
+    }
+    */
+
+}

--- a/Controller/SectionViewModel-iPad.swift
+++ b/Controller/SectionViewModel-iPad.swift
@@ -1,0 +1,50 @@
+//
+//  SectionViewModel-iPad.swift
+//  Bark
+//
+//  Created by sidguan on 2024/7/1.
+//  Copyright © 2024 Fin. All rights reserved.
+//
+
+import Foundation
+import RxCocoa
+import RxDataSources
+import RxSwift
+import Material
+
+struct SectionItem {
+    let image: UIImage?
+    let title: String
+}
+
+class SectionViewModel: ViewModel, ViewModelType {
+    struct Input {
+//        var sectionSelected: Driver<SectionItem>
+    }
+    
+    struct Output {
+        var items: Observable<[SectionModel<String, SectionItem>]>
+//        var selectedItem: Observable<SectionItem?>
+    }
+    
+    func initSectionItems() -> Observable<[SectionModel<String, SectionItem>]> {
+        return Observable.create { (observer) -> Disposable in
+            let sectionItems = [
+                SectionItem(image: UIImage(named: "baseline_gite_black_24pt"), title: NSLocalizedString("service")),
+                SectionItem(image: Icon.history, title: NSLocalizedString("historyMessage")),
+                SectionItem(image: UIImage(named: "baseline_manage_accounts_black_24pt"), title: NSLocalizedString("settings")),
+            ]
+            let section = [SectionModel(model: "", items: sectionItems)]
+            observer.onNext(section)
+            observer.onCompleted()
+            return Disposables.create()
+        }
+    }
+    
+    func transform(input: Input) -> Output {
+        let sectionItems = initSectionItems()
+        return Output(
+            items: sectionItems
+        )
+    }
+}

--- a/Controller/ServerListViewController.swift
+++ b/Controller/ServerListViewController.swift
@@ -124,9 +124,12 @@ class ServerListViewController: BaseViewController<ServerListViewModel> {
     func getServerAction() -> Driver<(Server, ServerActionType)> {
 
         return tableView.rx
-            .modelSelected(ServerListTableViewCellViewModel.self)
-            .flatMapLatest { viewModel -> PublishRelay<(Server, ServerActionType)> in
+            .itemSelected
+            .flatMapLatest { indexPath in
                 let relay = PublishRelay<(Server, ServerActionType)>()
+                guard let viewModel: ServerListTableViewCellViewModel = try? self.tableView.rx.model(at: indexPath)  else {
+                    return relay;
+                }
 
                 let alertController = UIAlertController(title: nil, message: "\(viewModel.address.value)", preferredStyle: .actionSheet)
                 alertController.addAction(UIAlertAction(title: NSLocalizedString("copyAddressAndKey"), style: .default, handler: { _ in
@@ -157,6 +160,14 @@ class ServerListViewController: BaseViewController<ServerListViewModel> {
                 }))
 
                 alertController.addAction(UIAlertAction(title: NSLocalizedString("Cancel"), style: .cancel, handler: nil))
+                
+                if UIDevice.current.userInterfaceIdiom == .pad {
+                    alertController.modalPresentationStyle = .popover
+                    if let cell = self.tableView.cellForRow(at: indexPath) {
+                        alertController.popoverPresentationController?.sourceView = self.tableView
+                        alertController.popoverPresentationController?.sourceRect = cell.frame
+                    }
+                }
                 self.navigationController?.present(alertController, animated: true, completion: nil)
 
                 return relay


### PR DESCRIPTION
看到 [这个 issue](https://github.com/Finb/Bark/issues/118)有感，这么实用的应用如果能支持 iPad 就更好了，Swift/RX 苦手，略尽绵力。

代码改动似乎不小，以下希望能帮助 Review：
- Bark/AppDelegate 增加判断版本跟设备型号，如果是 iPad 设备改用系统的 UISplitViewController 承载
- iPad 布局代码：BarkSplitViewController, SectionViewController-iPad, SectionViewModel-iPad
- 其他的改动都是为了适配 iPad actionSheet 的展示，由 `rx.modelSelected` 改为 `rx.itemSelected`，改由增加传递 indexPath，方便 actionSheet popover 能正确定位 sourceView，否则 iPad 下单纯展示 actionSheet 会直接出现崩溃

已自测已知路径，能正常支持 iPad 分屏模式：
![Simulator Screenshot - iPad Air (5th generation) - 2024-08-17 at 17 15 18](https://github.com/user-attachments/assets/2150cc12-acba-48a7-946f-2e9c7f4a5ce6)
![Simulator Screenshot - iPad Air (5th generation) - 2024-08-17 at 17 17 24](https://github.com/user-attachments/assets/591161ba-ffd0-498a-b53f-474c4a0bec7b)
![Simulator Screenshot - iPad Air (5th generation) - 2024-08-17 at 17 17 45](https://github.com/user-attachments/assets/6a7b6135-ce73-4705-a0bc-77081adc03f0)
