### PR TITLE
添加 bark.js 链接到 README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ Critical alerts will ignore silent and do not disturb modes, always playing the 
 - [Quicker Actions](https://getquicker.net/Sharedaction?code=e927d844-d212-4428-758d-08d69de12a3b)
 - [Bark for Wox](https://github.com/Zeroto521/Wox.Plugin.Bark)
 - [bark-jssdk](https://github.com/afeiship/bark-jssdk)
+- [bark.js](https://github.com/chimpdev/bark.js)
 - [java-bark-server](https://gitee.com/hotlcc/java-bark-server)
 - [bark-java-sdk](https://github.com/MoshiCoCo/bark-java-sdk)
 - [Python for Bark](https://github.com/funny-cat-happy/barknotificator)


### PR DESCRIPTION
I released the [@thiskyhan/bark.js](https://github.com/chimpdev/bark.js) package that helps simple push operations with bark using javascript in NPM. I think it might be useful to add this to the README.md file.

This pull request includes a small change to the `README.md` file. The change adds a new link to the list of related projects.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R91): Added a link to the `bark.js` project.