### PR TITLE
fix typo, trim space in URL structure example in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ You can send GET or POST requests, and you'll receive a push notification immedi
 URL structure: The first part is the key, followed by three matches
 /:key/:body 
 /:key/:title/:body 
-/:key/: title/:subtitle/:body 
+/:key/:title/:subtitle/:body 
 
 title: The push title, slightly larger than the body text 
 subtitle: The push subtitle


### PR DESCRIPTION
Trim space in url example in README.

In addition, there are many extra spaces at the tail of each line of the README file,
which don't affect the preview, so it is unclear whether to delete it.