### PR TITLE
Add PHP for Bark link to README files

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,3 +99,4 @@ Critical alerts will ignore silent and do not disturb modes, always playing the 
 - [bark-java-sdk](https://github.com/MoshiCoCo/bark-java-sdk)
 - [Python for Bark](https://github.com/funny-cat-happy/barknotificator)
 - [uTools for Bark](https://u.tools/plugins/detail/PushOne/)
+- [PHP for Bark](https://github.com/guanguans/notify/tree/main/src/Bark/)

--- a/README.zh.md
+++ b/README.zh.md
@@ -99,3 +99,4 @@ https://api.day.app/yourkey/时效性通知?level=critical
 - [bark-java-sdk](https://github.com/MoshiCoCo/bark-java-sdk)
 - [Python for Bark](https://github.com/funny-cat-happy/barknotificator)
 - [uTools for Bark](https://u.tools/plugins/detail/PushOne/)
+- [PHP for Bark](https://github.com/guanguans/notify/tree/main/src/Bark/)


### PR DESCRIPTION
- Added a new link to the PHP for Bark repository in both English and Chinese README files.
- This provides users with additional resources for integrating Bark with PHP.