### PR TITLE
支持输入 Hex 格式的 AES Key 和 IV (不再强制 UTF-8)

### DIFF
--- a/Controller/CryptoSettingViewModel.swift
+++ b/Controller/CryptoSettingViewModel.swift
@@ -127,7 +127,7 @@ class CryptoSettingViewModel: ViewModel, ViewModelType {
                         const iv = '\(iv)';
 
                         // AES-\(fields.algorithm.suffix(3))-GCM
-                        const cipher = crypto.createCipheriv('aes-\(fields.algorithm.suffix(3))-gcm', Buffer.from(key, 'utf8'), Buffer.from(iv, 'utf8'));
+                        const cipher = crypto.createCipheriv('aes-\(fields.algorithm.suffix(3))-gcm', Buffer.from(key, \(key.count == (Int(fields.algorithm.suffix(3))! / 4) ? "'hex'" : "'utf8'")), Buffer.from(iv, \(iv.count == (fields.mode == "GCM" ? 12 : 16) * 2 ? "'hex'" : "'utf8'")));
                         const encrypted = Buffer.concat([
                           cipher.update(json, 'utf8'),
                           cipher.final()
@@ -163,8 +163,8 @@ class CryptoSettingViewModel: ViewModel, ViewModelType {
                         iv='\(iv)'
 
                         # \("opensslEncodingComment".localized)
-                        key=$(printf $key | xxd -ps -c 200)
-                        iv=$(printf $iv | xxd -ps -c 200)
+                        \(key.count == (Int(fields.algorithm.suffix(3))! / 4) ? "# Key is already in Hex" : "key=$(printf $key | xxd -ps -c 200)")
+                        \(iv.count == (fields.mode == "GCM" ? 12 : 16) * 2 ? "# IV is already in Hex" : "iv=$(printf $iv | xxd -ps -c 200)")
                         
                         # \("base64Notice".localized)
                         ciphertext=$(echo -n $json | openssl enc -aes-\(fields.algorithm.suffix(3))-\(fields.mode.lowercased()) -K $key \(iv.count > 0 ? "-iv $iv " : "")| base64)

--- a/docs/en-us/encryption.md
+++ b/docs/en-us/encryption.md
@@ -19,17 +19,31 @@ deviceKey='F5u42Bd3HyW8KxkUqo2gRA'
 # push payload
 json='{"body": "test", "sound": "birdsong"}'
 
-# must be 16 bit long
+# Key
+# Can be a 16-byte raw string (length 16) or a Hex string (length 32)
 key='1234567890123456'
-iv='1111111111111111'
 
-# openssl requires Hex encoding of manual keys and IVs, not ASCII encoding.
+# IV
+# Method A: Randomly generate a 16-byte IV (Recommended) -> Output 32-char Hex string
+iv=$(openssl rand -hex 16)
+
+# Method B: Manually specify a 16-byte raw string (Legacy compatibility)
+# iv='1234567890123456'
+
+# Process Key and IV
+# If key/iv is a raw string, convert to Hex using xxd. If it is already a Hex string, use directly.
+# Demonstrating raw string conversion for Key:
 key=$(printf $key | xxd -ps -c 200)
-iv=$(printf $iv | xxd -ps -c 200)
+
+# If Key is Hex (e.g. 32 chars), use directly: 
+# key='...' (no xxd)
+
+# IV is already a Hex string (Method A), no xxd conversion needed.
+# If using Method B (raw string), you need: iv=$(printf $iv | xxd -ps -c 200)
 
 ciphertext=$(echo -n $json | openssl enc -aes-128-cbc -K $key -iv $iv | base64)
 
-# The console will print "d3QhjQjP5majvNt5CjsvFWwqqj2gKl96RFj5OO+u6ynTt7lkyigDYNA3abnnCLpr"
+# The console will print the ciphertext
 echo $ciphertext
 
 curl --data-urlencode "ciphertext=$ciphertext" http://api.day.app/$deviceKey

--- a/docs/encryption.md
+++ b/docs/encryption.md
@@ -19,18 +19,30 @@ deviceKey='F5u42Bd3HyW8KxkUqo2gRA'
 # push payload
 json='{"body": "test", "sound": "birdsong"}'
 
-# Must be 16 bit long
+# 密钥 (Key)
+# 可以是 16 字节的普通字符串 (长度16)，也可以是 Hex 编码字符串 (长度32)
 key='1234567890123456'
-# IV can be randomly generated, but if it is random, it needs to be passed in the iv parameter.
-iv='1234567890123456'
 
-# openssl requires Hex encoding of manual keys and IVs, not ASCII encoding.
+# 初始向量 (IV)
+# 方式 A：随机生成 16 字节 IV (推荐) -> 输出 32 字符的 Hex 字符串
+iv=$(openssl rand -hex 16)
+
+# 方式 B：手动指定 16 字节字符串 (兼容旧版)
+# iv='1234567890123456'
+
+# 处理 Key 和 IV
+# 如果 key/iv 是普通字符串，需要转成 Hex。如果是 Hex 字符串，则直接使用。
+# 这里演示 key 是普通字符串的情况：
 key=$(printf $key | xxd -ps -c 200)
-iv=$(printf $iv | xxd -ps -c 200)
+# 如果 Key 是 Hex (例如 32 字符)，则直接使用: 
+# key='...' (无需 xxd)
+
+# iv 已经是 Hex 字符串 (方式 A)，无需 xxd 转换。
+# 如果使用方式 B (普通字符串)，则需要：iv=$(printf $iv | xxd -ps -c 200)
 
 ciphertext=$(echo -n $json | openssl enc -aes-128-cbc -K $key -iv $iv | base64)
 
-# The console will print "+aPt5cwN9GbTLLSFri60l3h1X00u/9j1FENfWiTxhNHVLGU+XoJ15JJG5W/d/yf0"
+# The console will print the ciphertext
 echo $ciphertext
 
 # URL encoding the ciphertext, there may be special characters.


### PR DESCRIPTION
之前的逻辑强制把 Key 和 IV 当成普通字符串 (UTF-8) 处理, 导致不兼容 OpenSSL 生成标准的随机密钥

给 Key 和 IV 添加智能判断：
如果长度等于标准长度（比如 16），照旧按普通字符串处理 -> 兼容老版本。
如果长度是标准的 2 倍（比如 32）且是有效的 Hex，自动转成二进制数据处理 -> 支持 Hex 输入。
现在 AES 初始化使用 [UInt8] 字节数组。

同时对文档进行了更新

我不太懂ios开发, 最近在使用的时候, 尝试使用`openssl rand -hex 16`作为 iv, 遇到了这个问题,
尝试修改了一下, 希望能有帮助