### PR TITLE
feat: 在设置页面添加服务器列表入口

### DIFF
--- a/Controller/MessageSettingsViewController.swift
+++ b/Controller/MessageSettingsViewController.swift
@@ -178,6 +178,11 @@ class MessageSettingsViewController: BaseViewController<MessageSettingsViewModel
         
         let dataSource = RxTableViewSectionedReloadDataSource<SectionModel<MessageSettingSection, MessageSettingItem>> { _, tableView, _, item -> UITableViewCell in
             switch item {
+            case .servers:
+                if let cell = tableView.dequeueReusableCell(withIdentifier: "\(DetailTextCell.self)") as? DetailTextCell {
+                    cell.textLabel?.text = "serverList".localized
+                    return cell
+                }
             case .label(let text):
                 if let cell = tableView.dequeueReusableCell(withIdentifier: "\(LabelCell.self)") as? LabelCell {
                     cell.textLabel?.text = text
@@ -239,6 +244,13 @@ class MessageSettingsViewController: BaseViewController<MessageSettingsViewModel
             .drive(tableView.rx.items(dataSource: dataSource))
             .disposed(by: rx.disposeBag)
      
+        // 打开服务器列表
+        output.openServerList.drive(onNext: { [weak self] in
+            let viewModel = ServerListViewModel()
+            let vc = ServerListViewController(viewModel: viewModel)
+            self?.navigationController?.pushViewController(vc, animated: true)
+        }).disposed(by: rx.disposeBag)
+
         // 打开 URL 操作
         output.openUrl.drive { [weak self] url in
             self?.navigationController?.present(BarkSFSafariViewController(url: url), animated: true, completion: nil)

--- a/Controller/MessageSettingsViewModel.swift
+++ b/Controller/MessageSettingsViewModel.swift
@@ -27,6 +27,7 @@ class MessageSettingsViewModel: ViewModel, ViewModelType {
     struct Output {
         var settings: Driver<[SectionModel<MessageSettingSection, MessageSettingItem>]>
         var openUrl: Driver<URL>
+        var openServerList: Driver<Void>
         var copyDeviceToken: Driver<String>
         var exportData: Driver<Data>
     }
@@ -54,7 +55,7 @@ class MessageSettingsViewModel: ViewModel, ViewModelType {
 
         let settings: [SectionModel<MessageSettingSection, MessageSettingItem>] = {
             var settings = [SectionModel<MessageSettingSection, MessageSettingItem>]()
-            
+
             // 历史消息
             var messageSettings = [MessageSettingItem]()
             messageSettings.append(.backup(viewModel: MutableTextCellViewModel(
@@ -85,6 +86,7 @@ class MessageSettingsViewModel: ViewModel, ViewModelType {
             
             // 信息
             var infosettings = [MessageSettingItem]()
+            infosettings.append(.servers)
             infosettings.append(.deviceToken(
                 viewModel: MutableTextCellViewModel(
                     title: "Device Token",
@@ -170,6 +172,11 @@ class MessageSettingsViewModel: ViewModel, ViewModelType {
             return nil
         }
 
+        let openServerList = input.itemSelected.compactMap { item -> Void? in
+            if case .servers = item { return () }
+            return nil
+        }
+
         let deviceTokenValue: BehaviorRelay<String?> = BehaviorRelay(value: nil)
         input.deviceToken.drive(deviceTokenValue)
             .disposed(by: rx.disposeBag)
@@ -202,6 +209,7 @@ class MessageSettingsViewModel: ViewModel, ViewModelType {
             settings: Driver<[SectionModel<MessageSettingSection, MessageSettingItem>]>
                 .just(settings),
             openUrl: openUrl,
+            openServerList: openServerList,
             copyDeviceToken: copyDeviceToken,
             exportData: exportSuccess.asDriver(onErrorDriveWith: .empty())
         )
@@ -209,6 +217,8 @@ class MessageSettingsViewModel: ViewModel, ViewModelType {
 }
 
 enum MessageSettingItem {
+    // 服务器列表
+    case servers
     // 普通标题标签
     case label(text: String)
     // 默认保存

--- a/Controller/ServerListViewController.swift
+++ b/Controller/ServerListViewController.swift
@@ -56,18 +56,23 @@ class ServerListViewController: BaseViewController<ServerListViewModel> {
     override func makeUI() {
         self.title = "serverList".localized
 
-        navigationItem.setRightBarButtonItem(item: UIBarButtonItem(customView: closeButton))
-
         self.view.addSubview(tableView)
         tableView.snp.makeConstraints { make in
             make.edges.equalToSuperview()
         }
         
-        closeButton.rx.tap.subscribe { [weak self] in
-            self?.dismiss(animated: true, completion: nil)
-        } onError: { _ in
-            
-        }.disposed(by: rx.disposeBag)
+    }
+
+    override func viewWillAppear(_ animated: Bool) {
+        super.viewWillAppear(animated)
+        // 仅在 modal 弹出时显示关闭按钮，push 时使用系统返回按钮
+        if self.navigationController?.presentingViewController != nil {
+            navigationItem.setRightBarButtonItem(item: UIBarButtonItem(customView: closeButton))
+            closeButton.rx.tap.subscribe { [weak self] in
+                self?.dismiss(animated: true, completion: nil)
+            } onError: { _ in
+            }.disposed(by: rx.disposeBag)
+        }
     }
 
     override func bindViewModel() {


### PR DESCRIPTION
## 背景

我想重置我的 device key，但在设置页面点击 Device Token 后发现并没有重置功能。在设置页中也找不到服务器管理的入口。于是我以为 Bark 没有实现 key 轮换功能，提交了一个实现该功能的 PR（已关闭）。

后来发现，重置 key 的功能实际上**已经实现了**——它在首页导航栏右上角的云朵图标中（服务器列表 → 点击服务器 → Reset Key）。这本质上是一个 UX 可发现性的问题：服务器管理功能隐藏在首页的一个不直观的图标后面，用户很自然地会去设置页面寻找，但找不到。

## 改动

在设置页面的 **Info** 分组中新增 **Server List** 入口（使用已有的 `DetailTextCell`，带 disclosure indicator），点击后 push 到已有的 `ServerListViewController`。

同时适配 `ServerListViewController` 的关闭按钮行为：
- 从首页 modal 弹出时：显示下箭头关闭按钮（dismiss）
- 从设置页 push 进入时：隐藏关闭按钮，使用系统返回按钮

无新增文件，无新增本地化字符串（复用已有的 `"serverList"`）。

## 测试计划

- [x] 本地构建通过
- [x] 模拟器验证：设置页 Info 分组显示 Server List cell
- [x] 点击 Server List → push 进入服务器列表，back button 正常返回
- [x] 首页云朵按钮仍正常 modal 弹出服务器列表，关闭按钮正常显示
- [x] 在服务器列表中执行操作（选择/重置/删除服务器）后首页标题正确更新

close #350